### PR TITLE
Support ArduinoJson versions >5 without deprecation warnings

### DIFF
--- a/src/uFire_SHT20_JSON.cpp
+++ b/src/uFire_SHT20_JSON.cpp
@@ -35,30 +35,42 @@ String uFire_SHT20_JSON::processJSON(String json)
 
 String uFire_SHT20_JSON::air_temp()
 {
-  String output;
+  #if ARDUINOJSON_VERSION_MAJOR < 6
   const size_t bufferSize = JSON_OBJECT_SIZE(1) + 20;
   DynamicJsonDocument doc(bufferSize);
+  #else
+  JsonDocument doc;
+  #endif
   doc["at"] = sht20->temperature();
+  String output;
   serializeJson(doc, output);
   return output;
 }
 
 String uFire_SHT20_JSON::air_humidity()
 {
-  String output;
+  #if ARDUINOJSON_VERSION_MAJOR < 6
   const size_t bufferSize = JSON_OBJECT_SIZE(1) + 20;
   DynamicJsonDocument doc(bufferSize);
+  #else
+  JsonDocument doc;
+  #endif
   doc["ah"] = sht20->humidity();
+  String output;
   serializeJson(doc, output);
   return output;
 }
 
 String uFire_SHT20_JSON::air_connected()
 {
-  String output;
+  #if ARDUINOJSON_VERSION_MAJOR < 6
   const size_t bufferSize = JSON_OBJECT_SIZE(1) + 20;
   DynamicJsonDocument doc(bufferSize);
+  #else
+  JsonDocument doc;
+  #endif
   doc["ac"] = sht20->connected();
+  String output;
   serializeJson(doc, output);
   return output;
 }

--- a/src/uFire_SHT20_MP.cpp
+++ b/src/uFire_SHT20_MP.cpp
@@ -35,30 +35,42 @@ String uFire_SHT20_MP::processMsgPack(String json)
 
 String uFire_SHT20_MP::air_temp()
 {
-  String output;
+  #if ARDUINOJSON_VERSION_MAJOR < 6
   const size_t bufferSize = JSON_OBJECT_SIZE(1) + 20;
   DynamicJsonDocument doc(bufferSize);
+  #else
+  JsonDocument doc;
+  #endif
   doc["at"] = sht20->temperature();
+  String output;
   serializeMsgPack(doc, output);
   return output;
 }
 
 String uFire_SHT20_MP::air_humidity()
 {
-  String output;
+  #if ARDUINOJSON_VERSION_MAJOR < 6
   const size_t bufferSize = JSON_OBJECT_SIZE(1) + 20;
   DynamicJsonDocument doc(bufferSize);
+  #else
+  JsonDocument doc;
+  #endif
   doc["ah"] = sht20->humidity();
+  String output;
   serializeMsgPack(doc, output);
   return output;
 }
 
 String uFire_SHT20_MP::air_connected()
 {
-  String output;
+  #if ARDUINOJSON_VERSION_MAJOR < 6
   const size_t bufferSize = JSON_OBJECT_SIZE(1) + 20;
   DynamicJsonDocument doc(bufferSize);
+  #else
+  JsonDocument doc;
+  #endif
   doc["ac"] = sht20->connected();
+  String output;
   serializeMsgPack(doc, output);
   return output;
 }


### PR DESCRIPTION
Projects using ArduinoJson version 6 and higher get deprecation warnings while building. This PR fixes that.